### PR TITLE
Change 0.0.0.0 ip to localhost for server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task('dev', ['watch', 'serve']);
 gulp.task('serve', function() {
   gulp.src('build')
     .pipe(webserver({
-      host: '0.0.0.0',
+      host: 'localhost',
       open: true
     }));
 });


### PR DESCRIPTION
It seems that we cannot use url like "xxxx/home" if we are using 0.0.0.0 as
server IP.

So we use a more convenient uri as "localhost"
